### PR TITLE
feat: add wgebra user-guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ build
 
 # Ignore these because they are generated automatically from docs/user_guides/templates
 docs/user_guides/wgcore
+docs/user_guides/wgebra
+docs/user_guides/wgparry
+docs/user_guides/wgrapier
 docs/user_guides/templates_injected
 tmp_*

--- a/docs-examples/inject_file/Cargo.lock
+++ b/docs-examples/inject_file/Cargo.lock
@@ -1010,6 +1010,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "strinject"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79ce5b3b5ce459098bc98e5c0611fe6ba2ad910887b64b8674441e6df7592f8"
 dependencies = [
  "regex",
  "reqwest",

--- a/docs-examples/inject_file/Cargo.toml
+++ b/docs-examples/inject_file/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-strinject = { path = "../../../strinject", features = ["download"] }
+strinject = { version = "0.2", features = ["download"] }

--- a/docs/about_wgmath.mdx
+++ b/docs/about_wgmath.mdx
@@ -23,8 +23,3 @@ welcome!
 
 The **wgcore** crate part of the **wgmath** ecosystem exposes a set of proc-macros to facilitate sharing and composing
 shaders across Rust libraries.
-
-**wgmath** is developed by the [Dimforge](https://dimforge.com) open-source company. You can support us by sponsoring us
-on [GitHub sponsor](https://github.com/sponsors/dimforge).
-
-![dimforge_logo](https://www.dimforge.com/img/logo/logo_dimforge_full)

--- a/docs/user_guides/templates/wgebra/blas_operations.mdx
+++ b/docs/user_guides/templates/wgebra/blas_operations.mdx
@@ -1,0 +1,286 @@
+---
+id: blas_operations
+title: Matrix multiplication, BLAS
+sidebar_label: Matrix multiplication, BLAS
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Matrix multiplication
+
+WGebra implements matrix-matrix and matrix-vector multiplications. It also supports 3-tensors where each element along
+the third dimensions is seen as an individual matrix. These shaders are designed for large matrices and are not
+composable. Instead, they expose compute pipelines for dispatching the operation to the GPU.
+
+The non-composable shaders are `Gemm` (for matrix-matrix multiplication) and `Gemv` (for matrix-vector multiplication),
+following the well-known BLAS terminology. Each of these shaders actually contain several compute pipelines, also
+providing variants where the left-hand-side matrix is transposed, as well as variants with some work-in-progress
+optimizations.
+
+:::tip Quantized matrices
+WGebra only implements linear algebra on **f32 matrices**. If you are looking for linear algebra on **quantized matrices**,
+(for example for AI), see the [wgml](https://github.com/dimforge/wgml) crate instead.
+:::
+
+<Tabs
+groupId="wgebra"
+defaultValue="gemm"
+values={[
+{label: 'gemm.rs', value: 'gemm'},
+{label: 'gemv.rs', value: 'gemv'},
+]}>
+<TabItem value="gemm">
+
+```rust
+async fn gpu_gemm() {
+    let gpu = GpuInstance::new().await.unwrap();
+    let gemm = super::Gemm::from_device(gpu.device()).unwrap();
+    let shapes = ViewShapeBuffers::new();
+
+    const NROWS: u32 = 256;
+    const NCOLS: u32 = 256;
+
+    /// Create some random matrices using nalgebra.
+    let m1_cpu = DMatrix::<f32>::new_random(NROWS as usize, NCOLS as usize);
+    let m2_cpu = DMatrix::<f32>::new_random(NCOLS as usize, NROWS as usize);
+
+    /// Convert our nalgebra matrices to GPU tensors.
+    let m1 = TensorBuilder::matrix(NROWS, NCOLS, BufferUsages::STORAGE)
+        .build_init(gpu.device(), m1_cpu.as_slice());
+    let m2 = TensorBuilder::matrix(NCOLS, NROWS, BufferUsages::STORAGE)
+        .build_init(gpu.device(), m2_cpu.as_slice());
+    /// GPU matrix that will contain the result.
+    let result =
+        TensorBuilder::matrix(NROWS, NROWS, BufferUsages::STORAGE | BufferUsages::COPY_SRC)
+            .build_init(gpu.device(), lhs_cpu.as_slice());
+    /// Buffer for reading back the operation result into RAM.
+    let staging = TensorBuilder::matrix(
+        NROWS,
+        NROWS,
+        BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+    )
+    .build(gpu.device());
+
+    for variant in [
+        /// m1 * m2
+        GemmVariant::Gemm,
+        /// transpose(m1) * m2
+        GemmVariant::GemmTr,
+        /// m1 * m2 using experimental optimizations.
+        GemmVariant::GemmFast,
+        /// transpose(m1) * m2 using experimental optimizations.
+        GemmVariant::GemmTrFast,
+    ] {
+        let mut encoder = gpu.device().create_command_encoder(&Default::default());
+        let mut pass = encoder.compute_pass("test", None);
+
+        // Dispatch the matrix multiplication operation for running it on the gpu.
+        gemm.dispatch_generic(
+            gpu.device(),
+            &shapes,
+            &mut pass,
+            result.as_embedded_view(),
+            m1.as_embedded_view(),
+            m2.as_embedded_view(),
+            variant,
+        );
+        drop(pass); // Ensure the pass is ended before the encoder is borrowed again.
+
+        staging.copy_from(&mut encoder, &result);
+
+        gpu.queue().submit(Some(encoder.finish()));
+
+        // Read the result and compare with the value computed on the CPU.
+        let gpu_result = staging.read(gpu.device()).await.unwrap();
+        let cpu_result = match variant {
+            GemmVariant::Gemm | GemmVariant::GemmFast => &m1_cpu * &m2_cpu,
+            GemmVariant::GemmTr | GemmVariant::GemmTrFast => m1_cpu.tr_mul(&m2_cpu),
+        };
+
+        let gpu_result = DMatrix::from_vec(NROWS as usize, NROWS as usize, gpu_result);
+        assert_relative_eq!(gpu_result, cpu_result, epsilon = 1.0e-3);
+    }
+}
+```
+  </TabItem>
+
+
+<TabItem value="gemv">
+
+```rust
+async fn gpu_gemv() {
+    let gpu = GpuInstance::new().await.unwrap();
+    let gemv = super::Gemv::from_device(gpu.device()).unwrap();
+    let shapes = ViewShapeBuffers::new();
+
+    const NROWS: u32 = 1024;
+    const NCOLS: u32 = 1024;
+
+    /// Create some random matrices/vectors using nalgebra.
+    let m_cpu = DMatrix::<f32>::new_random(NROWS as usize, NCOLS as usize);
+    let v_cpu = DVector::<f32>::new_random(NCOLS as usize);
+    let lhs_cpu = DVector::<f32>::new_random(NROWS as usize);
+
+    /// Convert our nalgebra matrices/vectors to GPU tensors.
+    let m = TensorBuilder::matrix(NROWS, NCOLS, BufferUsages::STORAGE)
+        .build_init(gpu.device(), m_cpu.as_slice());
+    let v = TensorBuilder::vector(v_cpu.nrows() as u32, BufferUsages::STORAGE)
+        .build_init(gpu.device(), v_cpu.as_slice());
+    /// GPU vector that will contain the result.
+    let result = TensorBuilder::vector(NROWS, BufferUsages::STORAGE | BufferUsages::COPY_SRC)
+        .build_init(gpu.device(), lhs_cpu.as_slice());
+    /// Buffer for reading back the operation result into RAM.
+    let staging = TensorBuilder::vector(NROWS, BufferUsages::MAP_READ | BufferUsages::COPY_DST)
+        .build(gpu.device());
+
+    for variant in [
+        /// m * v
+        GemvVariant::Gemv,
+        /// transpose(m) * v
+        GemvVariant::GemvTr,
+        /// m * v using experimental optimizations.
+        GemvVariant::GemvFast,
+        /// transpose(m) * v using experimental optimizations.
+        GemvVariant::GemvTrFast,
+    ] {
+        let mut encoder = gpu.device().create_command_encoder(&Default::default());
+        let mut pass = encoder.compute_pass("test", None);
+        // Dispatch the matrix multiplication operation for running it on the gpu.
+        gemv.dispatch_generic(gpu.device(), &shapes, &mut pass, &result, &m, &v, variant);
+        drop(pass); // Ensure the pass is ended before the encoder is borrowed again.
+
+        staging.copy_from(&mut encoder, &result);
+
+        gpu.queue().submit(Some(encoder.finish()));
+
+        // Read the result and compare with the value computed on the CPU.
+        let gpu_result = staging.read(gpu.device()).await.unwrap();
+        let cpu_result = match variant {
+            GemvVariant::Gemv | GemvVariant::GemvFast => &m_cpu * &v_cpu,
+            GemvVariant::GemvTr | GemvVariant::GemvTrFast => m_cpu.tr_mul(&v_cpu),
+        };
+
+        approx::assert_relative_eq!(DVector::from(gpu_result), cpu_result, epsilon = 1.0e-3);
+    }
+}
+```
+  </TabItem>
+</Tabs>
+
+## Componentwise operations
+
+The `OpAssign` shader provides componentwise operations between two vectors. The first (left-hand-side) vector is
+overwritten with the result of the operation. This can be used for calculating the **sum** or **difference** of two vectors,
+as well as their **componentwise product**, **division**. It can also be configured so that the first vector is simply overwritten
+with a **copy** of the second vector.
+
+<Tabs
+groupId="wgebra"
+defaultValue="op_assign"
+values={[
+{label: 'op_assign.rs', value: 'op_assign'},
+]}>
+<TabItem value="op_assign">
+
+```rust
+async fn gpu_op_assign() {
+    let ops = [
+        // a += b
+        OpAssignVariant::Add,
+        // a -= b
+        OpAssignVariant::Sub,
+        // a[i] *= b[i]
+        OpAssignVariant::Mul,
+        // a[i] /= b[i]
+        OpAssignVariant::Div,
+        // a = b
+        OpAssignVariant::Copy,
+    ];
+    let gpu = GpuInstance::new().await.unwrap();
+    let shapes = ViewShapeBuffers::new();
+
+    for op in ops {
+        let op_assign = OpAssign::new(gpu.device(), op).unwrap();
+        let mut encoder = gpu.device().create_command_encoder(&Default::default());
+
+        const LEN: u32 = 1757;
+
+        // Generate two random vectors.
+        let v0 = DVector::from_fn(LEN as usize, |i, _| i as f32 + 0.1);
+        let v1 = DVector::from_fn(LEN as usize, |i, _| i as f32 * 10.0 + 0.1);
+        // Convert the vectors to gpu 1-tensors.
+        // Note that `gpu_v0` is the one that will be overwritten with the result of the operation.
+        let gpu_v0 = TensorBuilder::vector(LEN, BufferUsages::STORAGE | BufferUsages::COPY_SRC)
+            .build_init(gpu.device(), v0.as_slice());
+        let gpu_v1 = TensorBuilder::vector(LEN, BufferUsages::STORAGE)
+            .build_init(gpu.device(), v1.as_slice());
+
+        let mut pass = encoder.compute_pass("test", None);
+        op_assign.dispatch(gpu.device(), &shapes, &mut pass, &gpu_v0, &gpu_v1);
+        drop(pass); // Ensure the pass is ended before the encoder is borrowed again.
+
+        gpu.queue().submit(Some(encoder.finish()));
+    }
+}
+```
+  </TabItem>
+</Tabs>
+
+## Vector reductions
+
+The `Reduce` shader provides the calculations combining all the components of a single vector to compute their
+**minimum**, **maximum**, **sum**, **product**, or **squared norm**. The selected operation is specified when
+instantiating the shader with `Reduce::new`.
+
+<Tabs
+groupId="wgebra"
+defaultValue="reductions"
+values={[
+{label: 'reductions.rs', value: 'reductions'},
+]}>
+<TabItem value="reductions">
+
+```rust
+async fn gpu_reduce() {
+    let gpu = GpuInstance::new().await.unwrap();
+    let shapes = ViewShapeBuffers::new();
+
+    let ops = [
+        // The minimum value among all the vector’s elements.
+        ReduceOp::Min,
+        // The maximum value among all the vector’s elements.
+        ReduceOp::Max,
+        // The sum of all the vector’s elements.
+        ReduceOp::Sum,
+        // Squared magnitude of the vector.
+        ReduceOp::SqNorm,
+        // The product of all the vector’s elements.
+        ReduceOp::Prod,
+    ];
+
+    for op in ops {
+        // Instanciate the shader (and compute pipeline) with the desired operation `op`.
+        let reduce = super::Reduce::new(gpu.device(), op).unwrap();
+        let mut encoder = gpu.device().create_command_encoder(&Default::default());
+
+        const LEN: usize = 345;
+        let numbers: DVector<f32> = DVector::new_random(LEN);
+
+        // Convert the vector to a GPU 1-tensor.
+        let vector = TensorBuilder::vector(numbers.len() as u32, BufferUsages::STORAGE)
+            .build_init(gpu.device(), numbers.as_slice());
+        // A single-element tensor that contains the result of the reduction.
+        let result = TensorBuilder::scalar(BufferUsages::STORAGE)
+            .build(gpu.device());
+
+        let mut pass = encoder.compute_pass("test", None);
+        reduce.dispatch(gpu.device(), &shapes, &mut pass, &vector, &result);
+        drop(pass); // Ensure the pass is ended before the encoder is borrowed again.
+
+        gpu.queue().submit(Some(encoder.finish()));
+    }
+}
+```
+  </TabItem>
+</Tabs>

--- a/docs/user_guides/templates/wgebra/geometric_transformations.mdx
+++ b/docs/user_guides/templates/wgebra/geometric_transformations.mdx
@@ -1,0 +1,203 @@
+---
+id: geometric_transformations
+title: Geometric transformations
+sidebar_label: Geometric transformations
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::warning
+Automatic WGSL docs generation publishable on this website is currently waiting on [wgpu#6364](https://github.com/gfx-rs/wgpu/pull/6364).
+In the meantime, refer to the WGSL sources in the [wgebra repository](https://github.com/dimforge/wgmath/tree/main/crates/wgebra).
+:::
+
+Most compute kernels for geometry, physics, robotics, games, etc. rely on some form of geometric transformations. While
+the WGSL specification gives access to raw transformation matrices through `mat2x2`, `mat3x3`, and `mat4x4`, these are
+both difficult to initialize and to use in practice is it is lacking utility functions to manipulate them.
+
+WGebra defines strongly typed transformations for ergonomic and efficient handling of common transformations: rotations
+(as complex numbers or quaternions) and similarities.
+
+:::note
+There is no strongly typed isometries. Use similarities with a scaling factor of 1 instead.
+:::
+
+## Rotations
+
+Using a `mat2x2` or `mat3x3` for representing a 2D or 3D rotation is both wasteful in terms of memory usage, as well as
+inefficient when it comes to operations like inversion. The `WgRot2` and `WgQuat` composable shaders expose reusable
+WGSL types and functions for representing and handling these rotations as a complex number (i.e. 2 floats) in 2D, or
+a quaternion (i.e. 4 floats) in 3D.
+
+### 2D rotations example
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgRot2), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::rot2 as R
+
+@group(0) @binding(0)
+var<storage, read_write> test_q1: array<R::Rot2>;
+@group(0) @binding(1)
+var<storage, read_write> test_q2: array<R::Rot2>;
+@group(0) @binding(2)
+var<storage, read_write> test_v1: array<vec3<f32>>;
+@group(0) @binding(3)
+var<storage, read_write> test_v2: array<vec3<f32>>;
+@group(0) @binding(4)
+var<storage, read_write> test_id: R::Rot2;
+
+@compute @workgroup_size(1, 1, 1)
+fn test(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    let i = invocation_id.x;
+    test_v1[i] = R::mulVec(test_q1[i], test_v1[i]);
+    test_v2[i] = R::invMulVec(test_q2[i],test_v2[i]);
+    test_q1[i] = R::mul(test_q1[i], test_q2[i]);
+    test_q2[i] = R::inv(test_q2[i]);
+
+    if i == 0 {
+        test_id = R::identity();
+    }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+### Quaternion example
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgQuat), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::quat as Q
+
+@group(0) @binding(0)
+var<storage, read_write> test_q1: array<Q::Quat>;
+@group(0) @binding(1)
+var<storage, read_write> test_q2: array<Q::Quat>;
+@group(0) @binding(2)
+var<storage, read_write> test_v1: array<vec3<f32>>;
+@group(0) @binding(3)
+var<storage, read_write> test_v2: array<vec3<f32>>;
+@group(0) @binding(4)
+var<storage, read_write> test_id: Q::Quat;
+
+@compute @workgroup_size(1, 1, 1)
+fn test(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    let i = invocation_id.x;
+    test_v1[i] = Q::mulVec(test_q1[i], test_v1[i]);
+    test_v2[i] = Q::invMulVec(test_q2[i],test_v2[i]);
+    test_q1[i] = Q::mul(test_q1[i], test_q2[i]);
+    test_q2[i] = Q::inv(test_q2[i]);
+
+    if i == 0 {
+        test_id = Q::identity();
+    }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## Similarities
+
+Similarities are transformations representing a uniform scaling factor, followed by a rotation, followed by a
+translation. They are a superset of isometries for which the scaling factor is always 1.
+
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgSim3), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::sim3 as Sim
+
+@group(0) @binding(0)
+var<storage, read_write> test_s1: array<Sim::Sim3>;
+@group(0) @binding(1)
+var<storage, read_write> test_s2: array<Sim::Sim3>;
+@group(0) @binding(2)
+var<storage, read_write> test_p1: array<vec3<f32>>;
+@group(0) @binding(3)
+var<storage, read_write> test_p2: array<vec3<f32>>;
+@group(0) @binding(4)
+var<storage, read_write> test_v1: array<vec3<f32>>;
+@group(0) @binding(5)
+var<storage, read_write> test_v2: array<vec3<f32>>;
+@group(0) @binding(6)
+var<storage, read_write> test_id: Sim::Sim3;
+
+@compute @workgroup_size(1, 1, 1)
+fn test(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    let i = invocation_id.x;
+    test_p1[i] = Sim::mulPt(test_s1[i], test_p1[i]);
+    test_p2[i] = Sim::invMulPt(test_s2[i],test_p2[i]);
+    test_v1[i] = Sim::mulVec(test_s1[i], test_v1[i]);
+    test_v2[i] = Sim::invMulVec(test_s2[i],test_v2[i]);
+    test_s1[i] = Sim::mul(test_s1[i], test_s2[i]);
+    test_s2[i] = Sim::inv(test_s2[i]);
+
+    if i == 0 {
+        test_id = Sim::identity();
+    }
+}
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/user_guides/templates/wgebra/matrix_decompositions.mdx
+++ b/docs/user_guides/templates/wgebra/matrix_decompositions.mdx
@@ -1,0 +1,288 @@
+---
+id: matrix_decompositions
+title: Matrix decompositions
+sidebar_label: Matrix decompositions
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::warning
+Automatic WGSL docs generation publishable on this website is currently waiting on [wgpu#6364](https://github.com/gfx-rs/wgpu/pull/6364).
+In the meantime, refer to the WGSL sources in the [wgebra repository](https://github.com/dimforge/wgmath/tree/main/crates/wgebra).
+:::
+
+Matrix decomposition is a family of techniques that aim to represent a matrix as
+the product of several matrices. Those factors can either allow more efficient
+operations like inversion or linear system resolution, and might provide some
+insight regarding intrinsic properties of some data to be analysed (e.g. by
+observing singular values, eigenvectors, etc.)
+
+:::info
+**WGebra** implements common matrix decompositions for low-dimensional matrices (currently `mat2x2<f32>`, `mat3x3<f32>`
+and `mat4x4<f32>`). There is no implementation of these decomposition for large matrices yet.
+:::
+
+Decomposition            | Factors                   | Derivable shaders
+-------------------------|---------------------------|--------------
+QR                       | $Q ~ R$                   | `WgQR2`, `WgQR3`, `WgQR4`
+LU with partial pivoting | $P^{-1} ~ L ~ U$          | `WgLU2`, `WgLU3`, `WgLU4`
+Cholesky                 | $L ~ L^*$                 | `WgCholesky2`, `WgCholesky3`, `WgCholesky4`
+Symmetric eigendecomposition | $U ~ \Lambda ~ U^*$   | `WgSymmetricEigen2`, `WgSymmetricEigen3`, `WgSymmetricEigen4`
+SVD (2x2 and 3x3 only)   | $U ~ \Sigma ~ V^*$        | `WgSvd2`, `WgSvd3`
+
+## Cholesky
+
+The Cholesky decomposition of a `n × n` Hermitian Definite Positive (SDP) matrix
+$M$ is composed of a `n × n` lower-triangular matrix $L$ such that $M = LL^*$.
+Where $L^*$ designates the conjugate-transpose of $L$.  If the input matrix is
+not SDP, such a decomposition does not exist and the matrix method
+`.cholesky(...)` returns `None`. Note that the input matrix is interpreted as a
+hermitian matrix. Only its lower-triangular part (including the diagonal) is
+read by the Cholesky decomposition (its strictly upper-triangular is never
+accessed in memory). See [the wikipedia
+article](https://en.wikipedia.org/wiki/Cholesky_decomposition) for further
+details about the Cholesky decomposition.
+
+Typical uses of the Cholesky decomposition include the inversion of SDP
+matrices and resolution of SDP linear systems.
+
+
+<div style={{textAlign: 'center'}}>
+
+![Cholesky decomposition of a 3x3 matrix.](https://nalgebra.rs/assets/images/cholesky-75dc99e2e735888f6626a84cad7e63ca.svg)
+
+</div>
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgCholesky3), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::cholesky3 as Chol
+
+// Example of function running the decomposition on a 3x3 matrix.
+fn my_function(m: mat3x3<f32>) {
+    let decomposition = Chol::cholesky(m);
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## QR
+
+The QR decomposition of a general `m × n` matrix $M$ is composed of an `m ×
+min(n, m)` unitary matrix $Q$, and a `min(n, m) × m` upper triangular matrix
+(or upper trapezoidal if $m < n$) $R$ such that $M = QR$. This can be used to
+compute the inverse or a matrix or for solving linear systems. See also [the
+wikipedia article](https://en.wikipedia.org/wiki/QR_decomposition) for further
+details.
+
+<div style={{textAlign: 'center'}}>
+
+![QR decomposition of a 3x3 matrix.](https://nalgebra.rs/assets/images/QR-c637c07671e0b3b667b54e70ea195a67.svg)
+
+</div>
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgQR3), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::qr3 as QR
+
+// Example of function running the decomposition on a 3x3 matrix.
+fn my_function(m: mat3x3<f32>) {
+    let decomposition = QR::qr(m);
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## LU with partial pivoting
+
+The LU decomposition of a general `m × n` matrix is composed of a `m × min(n,
+m)` lower triangular matrix $L$ with a diagonal filled with 1, and a `min(n, m)
+× m` upper triangular matrix $U$ such that $M = LU$. This decomposition is
+typically used for solving linear systems, compute determinants, matrix
+inverse, and matrix rank.
+
+WGebra implements `LU` decomposition with partial (row) pivoting which computes additionally
+only one permutation matrix $P$ such that $PM = LU$.
+
+See also [the wikipedia article](https://en.wikipedia.org/wiki/LU_decomposition) for further details.
+
+<div style={{textAlign: 'center'}}>
+
+![LU decomposition of a 3x3 matrix.](https://nalgebra.rs/assets/images/LU-e0e7218e88443b27cfafe74dbb63f28b.svg)
+
+</div>
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgLU3), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::lu3 as LU
+
+// Example of function running the decomposition on a 3x3 matrix.
+fn my_function(m: mat3x3<f32>) {
+    let decomposition = LU::lu(m);
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## Eigendecomposition (symmetric matrix)
+
+The eigendecomposition of a square symmetric matrix $M$ is composed of an
+unitary matrix $Q$ and a real diagonal matrix $\Lambda$ such that $M = Q\Lambda
+Q^*$. The columns of $Q$ are called the _eigenvectors_ of $M$ and the diagonal
+elements of $\Lambda$ its _eigenvalues_.
+
+The matrix $Q$ and the eigenvalues of the decomposed matrix are respectively
+accessible as public the fields `eigenvectors` and `eigenvalues` of the
+`SymmetricEigen` structure.
+
+<div style={{textAlign: 'center'}}>
+
+![Eigendecomposition of a 3x3 symmetric matrix.](https://nalgebra.rs/assets/images/symmetric_eigen-63031cc3f1a7d8e57497b26c16041f0b.svg)
+
+</div>
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgSymmetricEigen3), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::eig3 as Eig
+
+// Example of function running the decomposition on a 3x3 matrix.
+fn my_function(m: mat3x3<f32>) {
+    let decomposition = Eig::symmetric_eigen(m);
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## Singular Value Decomposition
+
+The Singular Value Decomposition (SVD) of a rectangular matrix is composed
+of two orthogonal matrices $U$ and $V$ and a diagonal matrix $\Sigma$ with positive
+(or zero) components. Typical uses of the SVD are the pseudo-inverse, rank
+computation, and the resolution of least-square problems.
+
+The singular values, left singular vectors, and right singular vectors are
+respectively stored on the public fields `singular_values`, `u` and `v_t`. Note
+that `v_t` represents the adjoint (i.e. conjugate-transpose) of the matrix $V$.
+
+<div style={{textAlign: 'center'}}>
+
+![SVD decomposition of a 3x3 matrix.](https://nalgebra.rs/assets/images/SVD-a3b626297ee186a529a2f3c3284eca21.svg)
+
+</div>
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgSvd3), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::svd3 as Svd
+
+// Example of function running the decomposition on a 3x3 matrix.
+fn my_function(m: mat3x3<f32>) {
+    let decomposition = Svd::svd(m);
+}
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/user_guides/templates/wgebra/utilities.mdx
+++ b/docs/user_guides/templates/wgebra/utilities.mdx
@@ -1,0 +1,105 @@
+---
+id: utilities
+title: Utilities
+sidebar_label: Utilities
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::warning
+Automatic WGSL docs generation publishable on this website is currently waiting on [wgpu#6364](https://github.com/gfx-rs/wgpu/pull/6364).
+In the meantime, refer to the WGSL sources in the [wgebra repository](https://github.com/dimforge/wgmath/tree/main/crates/wgebra).
+:::
+
+WGebra provides a few utilities that are generally useful in mathematical code but are missing from the WebGPU standard.
+
+## Component reductions
+
+Calculating the minimum or maximum element of a `vec2`, `vec3`, `vec4`, `mat2x2`, `mat3x3`, `mat4x4` is rather verbose
+with vanilla WGSL code. The `WgMinMax` composable shader exposes functions for computing it in your shader:
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgMinMax), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::min_max as MM
+
+// Dummy function that calls all the supported component mins or maxes for matrices,
+// from the `min_max` module (imported as `MM` here).
+fn compute_all_min_maxes(a: mat2x2<f32>, b: mat3x3<f32>, c: mat4x4<f32>) {
+    let all_mins = vec3(MM::min2x2(a), MM::min3x3(b), MM::min4x4(c));
+    let all_abs_mins = vec3(MM::amin2x2(a), MM::amin3x3(b), MM::amin4x4(c));
+    let all_maxs = vec3(MM::max2x2(a), MM::max3x3(b), MM::max4x4(c));
+    let all_abs_maxs = vec3(MM::amax2x2(a), MM::amax3x3(b), MM::amax4x4(c));
+    // TODO: do something with all that.
+}
+```
+
+  </TabItem>
+</Tabs>
+
+
+## Stable tangents
+
+In some platforms (especially Metal/MacOS) provide numerically unstable implementations of some trigonometric functions,
+potentially leading to NaNs for some edge-cases. The `WgTrig` module exposes implementations of `tanh` and `atan2` that
+will be more numerically stable across platforms.
+
+<Tabs
+groupId="wgebra"
+defaultValue="rust"
+values={[
+{label: 'main.rs', value: 'rust'},
+{label: 'your_shader.wgsl', value: 'wgsl'},
+]}>
+<TabItem value="rust">
+
+```rust
+#[derive(Shader)]
+#[shader(derive(WgTrig), src = "your_shader.wgsl")]
+struct YourShader;
+
+// Automatically generates a test to check with `cargo test` if `your_shader.wgsl` compiles.
+wgcore::test_shader_compilation!(YourShader);
+```
+
+  </TabItem>
+  <TabItem value="wgsl">
+
+```rust
+#import wgebra::trig as Trig
+
+// Dummy function that calls some edge-cases for trigonometric functions that
+// are not well handled on Metal.
+fn compute_edge_cases() {
+    // This would have returned NaN on Metal, instead of a value close to 1.
+    // See https://github.com/apache/tvm/pull/16438
+    let tan_large_value = Trig::stable_tanh(46.0);
+    // This would return NaN on Metal. The Trig module will return 0 on unbounded cases instead.
+    // See https://github.com/gfx-rs/wgpu/issues/4319
+    let atan_edge_case = Trig::stable_atan2(0.0, 0.0);
+}
+```
+
+  </TabItem>
+</Tabs>
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,12 +85,12 @@ const config = {
         },
         footer: {
             style: 'dark',
-            logo: {
-                alt: 'Dimforge EURL Logo',
-                src: 'https://www.dimforge.com/img/logo/logo_dimforge_small_rect.svg',
-                href: 'https://www.dimforge.com/'
-            },
-            copyright: `Built by <a href="https://www.dimforge.com">Dimforge, EURL</a>.`,
+            // logo: {
+            //     alt: 'Dimforge EURL Logo',
+            //     src: 'https://www.dimforge.com/img/logo/logo_dimforge_small_rect.svg',
+            //     href: 'https://www.dimforge.com/'
+            // },
+            // copyright: `Built by <a href="https://www.dimforge.com">Dimforge, EURL</a>.`,
             links: [
                 // {
                 //     title: 'Resources',

--- a/generate_user_guides.sh
+++ b/generate_user_guides.sh
@@ -5,3 +5,8 @@ mkdir -p docs/user_guides/wgcore/
 find docs/user_guides/templates/wgcore -type f -print0 | OUTPUT_FOLDER=docs/user_guides/templates_injected xargs -0 ./inject_code_in_user_guides.sh
 cp -r docs/user_guides/templates_injected/* docs/user_guides/wgcore/.
 rm -rf docs/user_guides/templates_injected
+
+mkdir -p docs/user_guides/wgebra/
+find docs/user_guides/templates/wgebra -type f -print0 | OUTPUT_FOLDER=docs/user_guides/templates_injected xargs -0 ./inject_code_in_user_guides.sh
+cp -r docs/user_guides/templates_injected/* docs/user_guides/wgebra/.
+rm -rf docs/user_guides/templates_injected

--- a/sidebar_docs.js
+++ b/sidebar_docs.js
@@ -10,6 +10,12 @@ let templates = {
                 'user_guides/templates/wgcore/timestamp_queries',
                 'user_guides/templates/wgcore/overwriting_shaders'
             ],
+            'WGebra Book': [
+                'user_guides/templates/wgebra/matrix_decompositions',
+                'user_guides/templates/wgebra/blas_operations',
+                'user_guides/templates/wgebra/geometric_transformations',
+                'user_guides/templates/wgebra/utilities',
+            ]
         }
     ]
 };
@@ -23,6 +29,12 @@ let templates_injected = {
         'user_guides/wgcore/timestamp_queries',
         'user_guides/wgcore/overwriting_shaders'
     ],
+    'WGebra Book': [
+        'user_guides/wgebra/matrix_decompositions',
+        'user_guides/wgebra/blas_operations',
+        'user_guides/wgebra/geometric_transformations',
+        'user_guides/wgebra/utilities',
+    ]
 }
 
 let user_guides;
@@ -41,16 +53,16 @@ const config = {
     docs: [
         'about_wgmath',
         user_guides,
-        {
-            'WGSL Documentation': [
-                'api/wgblas-api-doc',
-                'api/wgebra-api-doc',
-                'api/wgparry2d-api-doc',
-                'api/wgparry3d-api-doc',
-                'api/wgrapier2d-api-doc',
-                'api/wgrapier3d-api-doc',
-            ],
-        }
+        // {
+        //     'WGSL Documentation': [
+        //         'api/wgblas-api-doc',
+        //         'api/wgebra-api-doc',
+        //         'api/wgparry2d-api-doc',
+        //         'api/wgparry3d-api-doc',
+        //         'api/wgrapier2d-api-doc',
+        //         'api/wgrapier3d-api-doc',
+        //     ],
+        // }
     ],
 };
 


### PR DESCRIPTION
This adds a user-guide for the `wgebra` library, featuring matrix decompositions, blas operations, and geometric transformations.

The guide is published to https://wgmath.rs/docs/ (See the WGebra Book item.)